### PR TITLE
fix: pin Lacework provider version to ~> 1.5

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.0"
+      version = "~> 1.5"
     }
   }
 }


### PR DESCRIPTION
## Summary
We added the resource `lacework_integration_gcp_pub_sub_audit_log` in version `1.5.0` of our provider. 

- https://github.com/lacework/terraform-provider-lacework/releases/tag/v1.5.0

So we need to pin the version to anything above `1.5.x`

## Issue
https://lacework.atlassian.net/browse/GROW-1508
