### PR TITLE
fix: enable use of existing sink name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,13 +4,14 @@ locals {
   sink_name = length(var.existing_sink_name) > 0 ? var.existing_sink_name : (
     local.org_integration ? "${var.prefix}-${var.organization_id}-lacework-sink-${random_id.uniq.hex}" : "${var.prefix}-lacework-sink-${random_id.uniq.hex}"
   )
-  logging_sink_writer_identity = length(var.existing_sink_name) > 0 ? null : (
+  logging_sink_writer_identity = length(var.existing_sink_name) > 0 ? ["serviceAccount:${local.service_account_json_key.client_email}"] : (
     (local.org_integration) ? (
       [google_logging_organization_sink.lacework_organization_sink[0].writer_identity]
       ) : (
       [google_logging_project_sink.lacework_project_sink[0].writer_identity]
     )
   )
+
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->
This removes the condition of setting the `logging_sink_writer_identity` to null when the user supplied an existing sink name
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
`terraform plan `and `terraform apply `
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/GROW-1540
<!--
  Include the link to a Jira/Github issue
-->