### PR TITLE
fix: use browser role for service account in org level integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "google_project_iam_member" "for_lacework_service_account" {
 resource "google_organization_iam_member" "for_lacework_service_account" {
   count  = local.org_integration ? 1 : 0
   org_id = var.organization_id
-  role   = "roles/resourcemanager.organizationViewer"
+  role   = "roles/browser"
   member = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

For organization level integrations we need to be able to list projects. The previously granted role resourcemanager.organizationViewer was insufficient while the browser role provides the ability to list projects as well as retrieve organization level information so we are changing the role granted.

## How did you test this change?

Applied the terraform change on an org level GCP integration in GCP console by pointing the module source to the PR branch and running terraform apply. I verified that the org level role was changed to browser.
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->