### PR TITLE
feat(RAIN-66845): add existing topic and sub logic to gcp pub/sub terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,24 @@ cloudresourcemanager.googleapis.com
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_existing_sink_name"></a> [existing\_sink\_name](#input\_existing\_sink\_name) | The name of an existing sink to be re-used for this integration | `string` | `""` | no |
-| <a name="input_integration_type"></a> [integration\_type](#input\_integration\_type) | Specify the integration type. Can only be PROJECT or ORGANIZATION. Defaults to PROJECT | `string` | `"PROJECT"` | no |
-| <a name="input_labels"></a> [labels](#input\_labels) | Set of labels which will be added to the resources managed by the module | `map(string)` | `{}` | no |
-| <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF pub_sub_audit_log"` | no |
-| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The organization ID, required if integration\_type is set to ORGANIZATION | `string` | `""` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix that will be use at the beginning of every generated resource | `string` | `"lw-al-ps"` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | A project ID different from the default defined inside the provider | `string` | `""` | no |
-| <a name="input_pubsub_subscription_labels"></a> [pubsub\_subscription\_labels](#input\_pubsub\_subscription\_labels) | Set of labels which will be added to the subscription | `map(string)` | `{}` | no |
-| <a name="input_pubsub_topic_labels"></a> [pubsub\_topic\_labels](#input\_pubsub\_topic\_labels) | Set of labels which will be added to the topic | `map(string)` | `{}` | no |
-| <a name="input_required_apis"></a> [required\_apis](#input\_required\_apis) | n/a | `map(any)` | <pre>{<br>  "iam": "iam.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com"<br>}</pre> | no |
-| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The Service Account name (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
-| <a name="input_service_account_private_key"></a> [service\_account\_private\_key](#input\_service\_account\_private\_key) | The private key in JSON format, base64 encoded (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
-| <a name="input_use_existing_service_account"></a> [use\_existing\_service\_account](#input\_use\_existing\_service\_account) | Set this to true to use an existing Service Account | `bool` | `false` | no |
-| <a name="input_wait_time"></a> [wait\_time](#input\_wait\_time) | Amount of time to wait before the next resource is provisioned. | `string` | `"10s"` | no |
+| Name                                                                                                                                    | Description | Type | Default | Required |
+|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|------|---------|:--------:|
+| <a name="input_existing_sink_name"></a> [existing\_sink\_name](#input\_existing\_sink\_name)                                            | The name of an existing sink to be re-used for this integration | `string` | `""` | no |
+| <a name="input_existing_pub_sub_topic_id"></a> [existing\_pub\_sub\_topic\_id](#input\_existing\_pub\_sub\_topic\_id)                   | The name of an existing pub/sub topic to be re-used for this integration | `string` | `""` | no |
+| <a name="input_existing_pub_sub_subscription_name"></a> [existing\_pub\_sub\_subscription\_name](#input\_existing\_pub\_sub\_subscription\_name) | The name of an existing pub/sub subscription to be re-used for this integration | `string` | `""` | no |
+| <a name="input_integration_type"></a> [integration\_type](#input\_integration\_type)                                                    | Specify the integration type. Can only be PROJECT or ORGANIZATION. Defaults to PROJECT | `string` | `"PROJECT"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels)                                                                                    | Set of labels which will be added to the resources managed by the module | `map(string)` | `{}` | no |
+| <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name)                       | n/a | `string` | `"TF pub_sub_audit_log"` | no |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id)                                                       | The organization ID, required if integration\_type is set to ORGANIZATION | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix)                                                                                    | The prefix that will be use at the beginning of every generated resource | `string` | `"lw-al-ps"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                      | A project ID different from the default defined inside the provider | `string` | `""` | no |
+| <a name="input_pubsub_subscription_labels"></a> [pubsub\_subscription\_labels](#input\_pubsub\_subscription\_labels)                    | Set of labels which will be added to the subscription | `map(string)` | `{}` | no |
+| <a name="input_pubsub_topic_labels"></a> [pubsub\_topic\_labels](#input\_pubsub\_topic\_labels)                                         | Set of labels which will be added to the topic | `map(string)` | `{}` | no |
+| <a name="input_required_apis"></a> [required\_apis](#input\_required\_apis)                                                             | n/a | `map(any)` | <pre>{<br>  "iam": "iam.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com"<br>}</pre> | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name)                                      | The Service Account name (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
+| <a name="input_service_account_private_key"></a> [service\_account\_private\_key](#input\_service\_account\_private\_key)               | The private key in JSON format, base64 encoded (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
+| <a name="input_use_existing_service_account"></a> [use\_existing\_service\_account](#input\_use\_existing\_service\_account)            | Set this to true to use an existing Service Account | `bool` | `false` | no |
+| <a name="input_wait_time"></a> [wait\_time](#input\_wait\_time)                                                                         | Amount of time to wait before the next resource is provisioned. | `string` | `"10s"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,8 @@ module "lacework_al_ps_svc_account" {
 }
 
 resource "google_pubsub_topic" "lacework_topic" {
-  name       = "${var.prefix}-lacework-topic-${random_id.uniq.hex}"
+  count      = length(var.existing_pub_sub_topic_id) > 0 ? 0 : 1
+  name       = length(var.existing_pub_sub_topic_id) > 0 ? var.existing_pub_sub_topic_id : "${var.prefix}-lacework-topic-${random_id.uniq.hex}"
   project    = local.project_id
   depends_on = [google_project_service.required_apis]
   labels     = merge(var.labels, var.pubsub_topic_labels)
@@ -83,8 +84,9 @@ resource "google_pubsub_topic_iam_binding" "topic_publisher" {
 }
 
 resource "google_pubsub_subscription" "lacework_subscription" {
+  count                      = length(var.existing_pub_sub_subscription_name) > 0 ? 0 : 1
   project                    = local.project_id
-  name                       = "${var.prefix}-${local.project_id}-lacework-subscription-${random_id.uniq.hex}"
+  name                       = length(var.existing_pub_sub_subscription_name) > 0 ? var.existing_pub_sub_subscription_name : "${var.prefix}-${local.project_id}-lacework-subscription-${random_id.uniq.hex}"
   topic                      = google_pubsub_topic.lacework_topic.name
   ack_deadline_seconds       = 300
   message_retention_duration = "432000s"

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,11 @@ locals {
     )
   )
 
+  topic_name = length(var.existing_pub_sub_topic_id) > 0 ? var.existing_pub_sub_topic_id : "${var.prefix}-lacework-topic-${random_id.uniq.hex}"
+  topic_id = "projects/${local.project_id}/topics/${local.topic_name}"
+  subscription_name = length(var.existing_pub_sub_subscription_name) > 0 ? var.existing_pub_sub_subscription_name : "${var.prefix}-${local.project_id}-lacework-subscription-${random_id.uniq.hex}"
+  subscription_id = "projects/${local.project_id}/subscriptions/${local.subscription_name}"
+
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (
@@ -69,7 +74,7 @@ module "lacework_al_ps_svc_account" {
 
 resource "google_pubsub_topic" "lacework_topic" {
   count      = length(var.existing_pub_sub_topic_id) > 0 ? 0 : 1
-  name       = length(var.existing_pub_sub_topic_id) > 0 ? var.existing_pub_sub_topic_id : "${var.prefix}-lacework-topic-${random_id.uniq.hex}"
+  name       = local.topic_name
   project    = local.project_id
   depends_on = [google_project_service.required_apis]
   labels     = merge(var.labels, var.pubsub_topic_labels)
@@ -79,15 +84,15 @@ resource "google_pubsub_topic_iam_binding" "topic_publisher" {
   members    = local.logging_sink_writer_identity
   role       = "roles/pubsub.publisher"
   project    = local.project_id
-  topic      = google_pubsub_topic.lacework_topic[0].name
+  topic      = local.topic_name
   depends_on = [google_pubsub_topic.lacework_topic]
 }
 
 resource "google_pubsub_subscription" "lacework_subscription" {
   count                      = length(var.existing_pub_sub_subscription_name) > 0 ? 0 : 1
   project                    = local.project_id
-  name                       = length(var.existing_pub_sub_subscription_name) > 0 ? var.existing_pub_sub_subscription_name : "${var.prefix}-${local.project_id}-lacework-subscription-${random_id.uniq.hex}"
-  topic                      = google_pubsub_topic.lacework_topic[0].name
+  name                       = local.subscription_name
+  topic                      = local.topic_name
   ack_deadline_seconds       = 300
   message_retention_duration = "432000s"
   labels                     = merge(var.labels, var.pubsub_subscription_labels)
@@ -122,7 +127,7 @@ resource "google_pubsub_subscription_iam_binding" "lacework" {
   project      = local.project_id
   role         = "roles/pubsub.subscriber"
   members      = ["serviceAccount:${local.service_account_json_key.client_email}"]
-  subscription = google_pubsub_subscription.lacework_subscription[0].name
+  subscription = local.subscription_name
   depends_on   = [google_pubsub_subscription.lacework_subscription]
 }
 
@@ -187,8 +192,8 @@ resource "lacework_integration_gcp_pub_sub_audit_log" "default" {
   integration_type = var.integration_type
   project_id       = local.project_id
   organization_id  = var.organization_id
-  subscription_id  = google_pubsub_subscription.lacework_subscription[0].id
-  topic_id         = google_pubsub_topic.lacework_topic[0].id
+  subscription_id  = local.subscription_id
+  topic_id         = local.topic_id
   credentials {
     client_id      = local.service_account_json_key.client_id
     private_key_id = local.service_account_json_key.private_key_id

--- a/output.tf
+++ b/output.tf
@@ -10,7 +10,7 @@ output "service_account_private_key" {
 }
 
 output "pubsub_subscription_name" {
-  value       = google_pubsub_subscription.lacework_subscription.name
+  value       = google_pubsub_subscription.lacework_subscription[0].name
   description = "The PubSub subscription name"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -15,7 +15,7 @@ output "pubsub_subscription_name" {
 }
 
 output "pubsub_topic_name" {
-  value       = google_pubsub_topic.lacework_topic.name
+  value       = google_pubsub_topic.lacework_topic[0].name
   description = "The PubSub topic name"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -10,12 +10,12 @@ output "service_account_private_key" {
 }
 
 output "pubsub_subscription_name" {
-  value       = google_pubsub_subscription.lacework_subscription[0].name
+  value       = local.subscription_name
   description = "The PubSub subscription name"
 }
 
 output "pubsub_topic_name" {
-  value       = google_pubsub_topic.lacework_topic[0].name
+  value       = local.topic_name
   description = "The PubSub topic name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,18 @@ variable "existing_sink_name" {
   description = "The name of an existing sink to be re-used for this integration"
 }
 
+variable "existing_pub_sub_topic_id" {
+  type        = string
+  default     = ""
+  description = "The name of an existing pub/sub topic to be re-used for this integration"
+}
+
+variable "existing_pub_sub_subscription_name" {
+  type        = string
+  default     = ""
+  description = "The name of an existing pub/sub subscription to be re-used for this integration"
+}
+
 variable "prefix" {
   type        = string
   default     = "lw-al-ps"


### PR DESCRIPTION
## Summary

As we move towards migrating customers from GCPv1 to GCPv2, we need the terraform module to take in an existing topic and subscription name, on top of the already available option to specify an existing sink name, and use those existing resources (if passed), to create the new v2 integration, instead of creating new topic/subscription. Corresponding changes are being made to CLI to accept and send these arguments to the module.

## How did you test this change?

I tested these changes to the terraform module with the LW CLI to:

1. Create a v2 integration traditionally, i.e., have the module create a topic and subscription from scratch.
2. Create a v2 integration with existing pub/sub topic and subscription.

I monitored the changes on the LW console and GCP console to ensure that the respective resources were created/updated.

## Issue

[RAIN-66845](https://lacework.atlassian.net/browse/RAIN-66845?atlOrigin=eyJpIjoiMzUxM2E5MDQzOWZjNGFiYjg0MmVjOTBjZWM2YmExZWEiLCJwIjoiaiJ9)

[RAIN-66845]: https://lacework.atlassian.net/browse/RAIN-66845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ