### PR TITLE
Allows upgrading the google provider to 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cloudresourcemanager.googleapis.com
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lacework_al_ps_svc_account"></a> [lacework\_al\_ps\_svc\_account](#module\_lacework\_al\_ps\_svc\_account) | lacework/service-account/gcp | ~> 1.0 |
+| <a name="module_lacework_al_ps_svc_account"></a> [lacework\_al\_ps\_svc\_account](#module\_lacework\_al\_ps\_svc\_account) | lacework/service-account/gcp | ~> 2.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "google_project_service" "required_apis" {
 
 module "lacework_al_ps_svc_account" {
   source               = "lacework/service-account/gcp"
-  version              = "~> 1.0"
+  version              = "~> 2.0"
   create               = var.use_existing_service_account ? false : true
   service_account_name = local.service_account_name
   project_id           = local.project_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.1"
 
   required_providers {
-    google = ">= 4.4.0, < 5.0.0"
+    google = ">= 4.4.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
Similar to https://github.com/lacework/terraform-gcp-audit-log/pull/87 -- we can't use this module in our environment as the directory we want to declare this in is already using v5+ GCP resources. Using the old audit-log module creates the deprecated `storage` integration and we need to cut over to `pub-sub` by the end of the month per Lacework's imposed EOL deadline.

Description from the PR on the other module:
```
The google v5 provider is out since October 2023 and provides much needed features for us. But we can't upgrade to it because of lacework.

This allows lacework to work with google v5.x
```

## Summary

Similar to https://github.com/lacework/terraform-gcp-audit-log/pull/87 -- we can't use this module in our environment as the directory we want to declare this in is already using v5+ GCP resources. 

## How did you test this change?

I don't know a great way to test this, it's my first PR of this sort. If it'd be better as a GitHub Issue let me know and I can convert it over. 

## Issue

internal